### PR TITLE
FileDownloadStream.Read handles large block size

### DIFF
--- a/MFilesAPI.Extensions.Tests/MFilesAPI.Extensions.Tests.csproj
+++ b/MFilesAPI.Extensions.Tests/MFilesAPI.Extensions.Tests.csproj
@@ -1,17 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-
+    <TargetFramework>net462</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
+	  <PackageReference Include="MSTest" Version="3.3.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -20,12 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MFilesAPI.Extensions\MFilesAPI.Extensions.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="Interop.MFilesAPI">
-      <HintPath>..\lib\Interop.MFilesAPI.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Interop.MFilesAPI" Version="21.11.3" />
   </ItemGroup>
 
 </Project>

--- a/MFilesAPI.Extensions.Tests/packages.config
+++ b/MFilesAPI.Extensions.Tests/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
-  <package id="Moq" version="4.5.28" targetFramework="net45" />
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net45" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net45" />
-</packages>

--- a/MFilesAPI.Extensions/MFilesAPI.Extensions.csproj
+++ b/MFilesAPI.Extensions/MFilesAPI.Extensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Copyright>M-Files Corporation 2020 onwards</Copyright>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Version>1.0.6</Version>


### PR DESCRIPTION
Previously if an attempt was made to use `FileDownloadStream` to download a block greater in size to 4MB then an exception was thrown.  This limitation is noted on the [underlying COM API method](https://developer.m-files.com/APIs/COM-API/Reference/#MFilesAPI~VaultObjectFileOperations~DownloadFileInBlocks_ReadBlock.html) but was not visible inside the stream wrapper.

This change alters the wrapper such that, if the requested block size exceeds the internal limit, multiple requests are made to M-Files to download the block.

Added unit test to check internal API calls.