### PR TITLE
Potential fix for #16

### DIFF
--- a/MFilesAPI.Extensions/DisposableBase.cs
+++ b/MFilesAPI.Extensions/DisposableBase.cs
@@ -3,7 +3,7 @@
 namespace MFilesAPI.Extensions
 {
 	/// <summary>
-	/// A base class for objects implemtning the <see cref="IDisposable"/> pattern.
+	/// A base class for objects implementing the <see cref="IDisposable"/> pattern.
 	/// Override <see cref="DisposeManagedObjects"/> and/or <see cref="DisposeUnmanagedObjects"/> as appropriate.
 	/// <remarks>see: https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose?redirectedfrom=MSDN#implementing-the-dispose-pattern-for-a-base-class </remarks>
 	/// </summary>

--- a/MFilesAPI.Extensions/Email/EmailMessage.cs
+++ b/MFilesAPI.Extensions/Email/EmailMessage.cs
@@ -299,14 +299,14 @@ namespace MFilesAPI.Extensions.Email
 			this.mailMessage.Headers.Add(name, value);
 		}
 
-		protected override void Dispose(bool disposing)
-		{
+        protected override void DisposeManagedObjects()
+        {
 			// Attempt to dispose the mail message.
 			this.mailMessage?.Dispose();
 			this.mailMessage = null;
 
 			// Call the base implementation.
-			base.Dispose(disposing);
+			base.DisposeManagedObjects();
 		}
 
 		#endregion

--- a/MFilesAPI.Extensions/Email/EmailMessageBase.cs
+++ b/MFilesAPI.Extensions/Email/EmailMessageBase.cs
@@ -9,7 +9,7 @@ namespace MFilesAPI.Extensions.Email
 	/// A base implementation of <see cref="IEmailMessage"/> that plugins can extend.
 	/// </summary>
 	public abstract class EmailMessageBase
-		: IEmailMessage
+		: DisposableBase, IEmailMessage
 	{
 		private SmtpConfiguration configuration = null;
 
@@ -179,43 +179,6 @@ namespace MFilesAPI.Extensions.Email
 
 		/// <inheritdoc />
 		public abstract void AddHeader(string name, string value);
-
-		#endregion
-
-		#region IDisposable
-
-		/// <summary>
-		/// Disposes of any managed or unmanaged resources.
-		/// </summary>
-		/// <param name="disposing">If true, <see cref="IDisposable.Dispose"/> has been called.  False if called from within a finalizer.</param>
-		/// <remarks>
-		/// Unmanaged resources should be disposed of regardless of <paramref name="disposing" />.
-		/// Managed resources should be disposed of if <paramref name="disposing"/> is <see langword="true"/>.
-		/// More information on this pattern is available onlne: https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose
-		/// </remarks>
-		protected virtual void Dispose(bool disposing)
-		{
-		}
-
-		/// <inheritdoc />
-		/// <remarks>Calls <see cref="Dispose(bool)"/>, with disposing set to <see langword="true"/>.</remarks>
-		public void Dispose()
-		{
-			// Dispose of unmanaged resources.
-			this.Dispose(true);
-
-			// Suppress finalization.
-			GC.SuppressFinalize(this);
-		}
-
-		/// <summary>
-		/// Ensures that any resources are correctly disposed of during finalization.
-		/// </summary>
-		/// <remarks>Calls <see cref="Dispose(bool)"/>, with disposing set to <see langword="false"/>.</remarks>
-		~EmailMessageBase()
-		{
-			this.Dispose(false);
-		}
 
 		#endregion
 

--- a/MFilesAPI.Extensions/Files/Downloading/FileDownloadLocation.cs
+++ b/MFilesAPI.Extensions/Files/Downloading/FileDownloadLocation.cs
@@ -201,13 +201,13 @@ namespace MFilesAPI.Extensions
         }
 
         /// <inheritdoc />
-        protected override void Dispose(bool disposing)
+        protected override void DisposeManagedObjects()
         {
             // If we should clean on disposal then clean.
             if (this.CleanDirectoryOnDisposal)
                 this.CleanTemporaryFiles();
 
-            base.Dispose(disposing);
+            base.DisposeManagedObjects();
         }
 
     }


### PR DESCRIPTION
DisposableBase already had implementation of IDisposable that delegated to separate methods for managed/unmanaged objects Altered FileDownloadLocation to override DisposeManagedObjects instead of Dispose(bool) Altered EmailMessageBase to inherit from DisposableBase Altered EmailMessage to override DisposeManagedObjects instead of Dispose(bool) Spelling correction in DisposableBase